### PR TITLE
dp-api-clients-go v1.42.0 => v1.43.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-dimension-search-api
 go 1.16
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.42.0
+	github.com/ONSdigital/dp-api-clients-go v1.43.0
 	github.com/ONSdigital/dp-elasticsearch/v2 v2.2.0
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-import v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.40.0/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
-github.com/ONSdigital/dp-api-clients-go v1.42.0 h1:Iud2u1hKkqr487FPMshYPGr+U/Mkzo3L3Tga3Pvf8LY=
-github.com/ONSdigital/dp-api-clients-go v1.42.0/go.mod h1:A+Le3xoJU+P5/A91OOQPK9F5NTAGZ7V7Gd3EwpAsfqs=
+github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
+github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
 github.com/ONSdigital/dp-elasticsearch/v2 v2.2.0 h1:dnHq+0WZtKXIb0tFK//lc/eG8TXLNMwt5k+UnCiwLfM=
 github.com/ONSdigital/dp-elasticsearch/v2 v2.2.0/go.mod h1:f85VX6TzHkq3pM/ddUzufoFNTcx3FOi7VN+SQG0vMbg=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=


### PR DESCRIPTION
### What

Upgrade to logging v2 by upgrading dp-api-clients-go