### PR TITLE
updated search request path with rest_total_hits_as_int parameter to …

### DIFF
--- a/elasticsearch/api.go
+++ b/elasticsearch/api.go
@@ -59,7 +59,7 @@ func (api *API) DeleteSearchIndex(ctx context.Context, instanceID, dimension str
 func (api *API) QuerySearchIndex(ctx context.Context, instanceID, dimension, term string, limit, offset int) (*models.SearchResponse, int, error) {
 	response := &models.SearchResponse{}
 
-	path := api.url + "/" + instanceID + "_" + dimension + "/_search"
+	path := api.url + "/" + instanceID + "_" + dimension + "/_search?rest_total_hits_as_int=true"
 
 	logData := log.Data{"term": term, "path": path}
 


### PR DESCRIPTION
…aid with es migration from 6.8 to 7

### What

updated search request path with rest_total_hits_as_int parameter as hits.total is now an object and adding the parameter to ease the transition to the new version
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html#hits-total-now-object-search-response

### How to review

Check for typo and if it reads correct

### Who can review

Anyone
