### PR TITLE
Release 2.8.0

### DIFF
--- a/api/search.go
+++ b/api/search.go
@@ -123,7 +123,7 @@ func (api *SearchAPI) getSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	searchResults := &models.SearchResults{
-		TotalCount: response.Hits.Total,
+		TotalCount: response.Hits.Total.Value,
 		Limit:      page.Limit,
 		Offset:     page.Offset,
 	}

--- a/elasticsearch/api.go
+++ b/elasticsearch/api.go
@@ -59,7 +59,7 @@ func (api *API) DeleteSearchIndex(ctx context.Context, instanceID, dimension str
 func (api *API) QuerySearchIndex(ctx context.Context, instanceID, dimension, term string, limit, offset int) (*models.SearchResponse, int, error) {
 	response := &models.SearchResponse{}
 
-	path := api.url + "/" + instanceID + "_" + dimension + "/_search"
+	path := api.url + "/" + instanceID + "_" + dimension + "/_search?rest_total_hits_as_int=true"
 
 	logData := log.Data{"term": term, "path": path}
 

--- a/elasticsearch/api.go
+++ b/elasticsearch/api.go
@@ -85,11 +85,13 @@ func (api *API) QuerySearchIndex(ctx context.Context, instanceID, dimension, ter
 	logData["response_body"] = string(responseBody)
 
 	if err = json.Unmarshal(responseBody, response); err != nil {
+		log.Info(ctx, "unable to unmarshal json body - trying ES6 struct instead", logData)
 
 		// If we fail to marshall to ES7 then try the ES6 response struct instead
 		responseEs6 := &models.SearchResponseES6{}
-		if err = json.Unmarshal(responseBody, responseEs6); err != nil {
-			log.Error(ctx, "unable to unmarshal json body", err, logData)
+		if err6 := json.Unmarshal(responseBody, responseEs6); err6 != nil {
+			log.Error(ctx, "unable to unmarshal json body to ES7 struct", err, logData)
+			log.Error(ctx, "unable to unmarshal json body to ES6 struct", err6, logData)
 			return nil, status, errs.ErrUnmarshallingJSON
 		}
 		response = &models.SearchResponse{Hits: models.Hits{

--- a/mocks/elasticsearch.go
+++ b/mocks/elasticsearch.go
@@ -55,7 +55,10 @@ func (api *Elasticsearch) QuerySearchIndex(ctx context.Context, instanceID, dime
 
 	return &models.SearchResponse{
 		Hits: models.Hits{
-			Total:   22,
+			Total: models.Total{
+				Value:    22,
+				Relation: "eq",
+			},
 			HitList: []models.HitList{firstHit, secondHit},
 		},
 	}, http.StatusOK, nil

--- a/models/model.go
+++ b/models/model.go
@@ -12,13 +12,27 @@ func ErrorMaximumOffsetReached(m int) error {
 	return err
 }
 
+type SearchResponseES6 struct {
+	Hits HitsES6 `json:"hits"`
+}
+
+type HitsES6 struct {
+	Total   int       `json:"total"`
+	HitList []HitList `json:"hits"`
+}
+
 type SearchResponse struct {
 	Hits Hits `json:"hits"`
 }
 
 type Hits struct {
-	Total   int       `json:"total"`
+	Total   Total     `json:"total"`
 	HitList []HitList `json:"hits"`
+}
+
+type Total struct {
+	Value    int    `json:"value"`
+	Relation string `json:"relation"`
 }
 
 type HitList struct {


### PR DESCRIPTION
### What

Release branch containing…

- Add support for ES7 query responses which have changed the `hits.total` field from an int to a object of the form`{"value":123, "relation":"eq"}`. Code includes a fallback to support ES6 responses too.

### How to review

Ensure only the expected commits and tests pass.

### Who can review

Anyone but me