### PR TITLE
os.exit(1) after log.Fatal()

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	cfg, err := config.Get()
 	if err != nil {
 		log.Fatal(ctx, "failed to retrieve configuration", err)
+		os.Exit(1)
 	}
 
 	// sensitive fields are omitted from config.String().
@@ -133,6 +134,7 @@ func configureHealthChecks(ctx context.Context,
 	versionInfo, err := healthcheck.NewVersionInfo(BuildTime, GitCommit, Version)
 	if err != nil {
 		log.Fatal(ctx, "error creating version info", err)
+		os.Exit(1)
 	}
 
 	hc := healthcheck.New(versionInfo, cfg.HealthCheckCriticalTimeout, cfg.HealthCheckInterval)
@@ -172,5 +174,6 @@ func configureHealthChecks(ctx context.Context,
 func exitIfError(ctx context.Context, err error, message string) {
 	if err != nil {
 		log.Fatal(ctx, message, err)
+		os.Exit(1)
 	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -53,6 +53,7 @@ func (svc *Service) Start(ctx context.Context) {
 	SearchAPIURL, err := url.Parse(svc.SearchAPIURL)
 	if err != nil {
 		log.Fatal(ctx, "error parsing SearchAPIURL API URL", err, log.Data{"url": svc.SearchAPIURL})
+		os.Exit(1)
 	}
 
 	api.CreateSearchAPI(


### PR DESCRIPTION
### What

Terminate the program after log.Fatal().
This was removed in a previous PR due to linting but is required

### How to review

Check changes are ok

### Who can review

Anyone
